### PR TITLE
fixed: search bar for courses and packages

### DIFF
--- a/app/Http/Controllers/Api/v1/CourseApiController.php
+++ b/app/Http/Controllers/Api/v1/CourseApiController.php
@@ -63,7 +63,7 @@ class CourseApiController extends Controller
 
         $query = Course::query();
 
-        $searchableFields = ['course', 'national_code', 'aqf_level', 'title', 'tga_status', 'state_code', 'nominal_hours', 'type', 'qa', 'nat_code', 'nat_title'];
+        $searchableFields = ['national_code', 'aqf_level', 'title', 'tga_status', 'state_code', 'nominal_hours', 'type', 'qa', 'nat_code', 'nat_title', 'nat_code_title'];
 
         if ($search) {
             foreach ($searchableFields as $field) {

--- a/app/Http/Controllers/Api/v1/PackageApiController.php
+++ b/app/Http/Controllers/Api/v1/PackageApiController.php
@@ -65,7 +65,7 @@ class PackageApiController extends Controller
 
         $query = Package::with('courses');
 
-        $searchableFields = ['course', 'national_code', 'title', 'tga_status'];
+        $searchableFields = ['national_code', 'title', 'tga_status'];
 
         if ($search) {
             foreach ($searchableFields as $field) {

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -101,7 +101,7 @@ class CourseController extends Controller
 
         $query = Course::query();
 
-        $searchableFields = ['course', 'national_code', 'aqf_level', 'title', 'tga_status', 'state_code', 'nominal_hours', 'type', 'qa', 'nat_code', 'nat_title'];
+        $searchableFields = ['national_code', 'aqf_level', 'title', 'tga_status', 'state_code', 'nominal_hours', 'type', 'qa', 'nat_code', 'nat_title', 'nat_code_title'];
 
         if ($search) {
             foreach ($searchableFields as $field) {

--- a/app/Http/Controllers/PackageController.php
+++ b/app/Http/Controllers/PackageController.php
@@ -97,7 +97,7 @@ class PackageController extends Controller
 
         $query = Package::with('courses');
 
-        $searchableFields = ['courses', 'national_code', 'title', 'tga_status'];
+        $searchableFields = ['national_code', 'title', 'tga_status'];
 
         if ($search) {
             foreach ($searchableFields as $field) {

--- a/resources/views/courses/index.blade.php
+++ b/resources/views/courses/index.blade.php
@@ -3,6 +3,38 @@
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             {{ __('Course Management') }}
         </h2>
+        @auth
+            <div class="flex justify-end">
+            <form action="{{ route('courses.search') }}" method="POST" class="flex justify-end w-1/3 mx-5">
+                @csrf
+                <x-text-input type="text" name="keywords" placeholder="Course search..." value=""
+                              class="flex-grow px-4 py-2 focus:outline-none text-black w-full"/>
+                <x-primary-button type="submit"
+                                  class="bg-sky-500 hover:bg-sky-600 text-white px-4 py-2 pl-2focus:outline-none transition ease-in-out duration-500">
+                    <i class="fa fa-search"></i> {{ __('Search') }}
+                </x-primary-button>
+            </form>
+            </div>
+        @else
+            <div class="flex justify-end">
+            <form action="{{ route('search')  }}"
+                  method="POST" class="block mx-5">
+                @csrf
+
+                <x-text-input type="text" name="keywords" placeholder="Course search..." value=""
+                              class="w-full h-1/5 mr-2  md:w-auto px-4 py-2 focus:outline-none text-black"/>
+
+                <x-primary-button type="submit"
+                                  class="w-full md:w-auto
+                           bg-sky-500 hover:bg-sky-600
+                           text-white
+                           px-4 py-2
+                           focus:outline-none transition ease-in-out duration-500">
+                    <i class="fa fa-search"></i> {{ __('Search') }}
+                </x-primary-button>
+            </form>
+            </div>
+        @endauth
     </x-slot>
 
     @auth
@@ -16,35 +48,6 @@
 
                     <div class="flex justify-between items-center mb-6">
                         <h3 class="text-xl font-bold mb-6">Courses</h3>
-
-                        @auth
-                            <form action="{{ route('courses.search') }}" method="POST" class="flex justify-end mx-5">
-                                @csrf
-                                <x-text-input type="text" name="keywords" placeholder="Course search..." value=""
-                                              class="flex-grow px-4 py-2 focus:outline-none text-black w-full"/>
-                                <x-primary-button type="submit"
-                                                  class="bg-sky-500 hover:bg-sky-600 text-white px-4 py-2 pl-2focus:outline-none transition ease-in-out duration-500">
-                                    <i class="fa fa-search"></i> {{ __('Search') }}
-                                </x-primary-button>
-                            </form>
-                        @else
-                            <form action="{{ route('search')  }}"
-                                  method="POST" class="block mx-5">
-                                @csrf
-
-                                <x-text-input type="text" name="keywords" placeholder="Course search..." value=""
-                                              class="w-full h-1/5 mr-2  md:w-auto px-4 py-2 focus:outline-none text-black"/>
-
-                                <x-primary-button type="submit"
-                                                  class="w-full md:w-auto
-                           bg-sky-500 hover:bg-sky-600
-                           text-white
-                           px-4 py-2
-                           focus:outline-none transition ease-in-out duration-500">
-                                    <i class="fa fa-search"></i> {{ __('Search') }}
-                                </x-primary-button>
-                            </form>
-                        @endauth
 
                         <x-primary-link-button href="{{ route('courses.create') }}"
                                                class="bg-zinc-200 hover:bg-zinc-900 text-zinc-800 hover:text-white">

--- a/resources/views/packages/index.blade.php
+++ b/resources/views/packages/index.blade.php
@@ -4,6 +4,38 @@
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             {{ __('Package Management') }}
         </h2>
+        @auth
+            <div class="flex justify-end">
+                <form action="{{ route('packages.search') }}" method="POST" class="flex justify-end w-1/3 mx-5">
+                    @csrf
+                    <x-text-input type="text" name="keywords" placeholder="Package search..." value=""
+                                  class="flex-grow px-4 py-2 focus:outline-none text-black w-full"/>
+                    <x-primary-button type="submit"
+                                      class="bg-sky-500 hover:bg-sky-600 text-white px-4 py-2 pl-2focus:outline-none transition ease-in-out duration-500">
+                        <i class="fa fa-search"></i> {{ __('Search') }}
+                    </x-primary-button>
+                </form>
+            </div>
+        @else
+            <div class="flex justify-end">
+                <form action="{{ route('search')  }}"
+                      method="POST" class="block mx-5">
+                    @csrf
+
+                    <x-text-input type="text" name="keywords" placeholder="Package search..." value=""
+                                  class="w-full h-1/5 mr-2  md:w-auto px-4 py-2 focus:outline-none text-black"/>
+
+                    <x-primary-button type="submit"
+                                      class="w-full md:w-auto
+                           bg-sky-500 hover:bg-sky-600
+                           text-white
+                           px-4 py-2
+                           focus:outline-none transition ease-in-out duration-500">
+                        <i class="fa fa-search"></i> {{ __('Search') }}
+                    </x-primary-button>
+                </form>
+            </div>
+        @endauth
     </x-slot>
 
     @auth
@@ -17,35 +49,6 @@
 
                     <div class="flex justify-between items-center mb-6">
                         <h3 class="text-xl font-bold mb-6">Packages</h3>
-                        @auth
-                                <form action="{{ route('packages.search') }}" method="POST" class="flex justify-end mx-5">
-                                    @csrf
-                                    <x-text-input type="text" name="keywords" placeholder="Package search..." value=""
-                                                  class="flex-grow px-4 py-2 focus:outline-none text-black w-full"/>
-                                    <x-primary-button type="submit"
-                                                      class="bg-sky-500 hover:bg-sky-600 text-white px-4 py-2 pl-2focus:outline-none transition ease-in-out duration-500">
-                                        <i class="fa fa-search"></i> {{ __('Search') }}
-                                    </x-primary-button>
-                                </form>
-                        @else
-                            <form action="{{ route('search')  }}"
-                                  method="POST" class="block mx-5">
-                                @csrf
-
-                                <x-text-input type="text" name="keywords" placeholder="Package search..." value=""
-                                              class="w-full h-1/5 mr-2  md:w-auto px-4 py-2 focus:outline-none text-black"/>
-
-                                <x-primary-button type="submit"
-                                                  class="w-full md:w-auto
-                           bg-sky-500 hover:bg-sky-600
-                           text-white
-                           px-4 py-2
-                           focus:outline-none transition ease-in-out duration-500">
-                                    <i class="fa fa-search"></i> {{ __('Search') }}
-                                </x-primary-button>
-                            </form>
-                        @endauth
-
 
                         <x-primary-link-button href="{{ route('packages.create') }}"
                                                class="bg-zinc-200 hover:bg-zinc-900 text-zinc-800 hover:text-white">


### PR DESCRIPTION
fixed: search bar for courses and packages

## Summary by Sourcery

Fix search functionality for courses and packages by relocating the search forms into the header slot, removing redundant code blocks, and synchronizing searchable fields across API and web controllers.

Bug Fixes:
- Move course and package search forms to the top header slot and eliminate duplicate implementations below the list
- Remove obsolete 'course'/'courses' fields and add 'nat_code_title' where applicable in CourseApiController and CourseController search arrays
- Align PackageApiController and PackageController searchable fields by removing invalid entries